### PR TITLE
Buffering socket read.

### DIFF
--- a/src/CKIPClient.php
+++ b/src/CKIPClient.php
@@ -88,16 +88,13 @@ class CKIPClient
 
          $big5_string = '';
          $buf = '';
-         while( $buf = socket_read($socket, 1024)) {
+         while ($buf = socket_read($socket, 1024)) {
             $len = strlen($buf);
             if ($buf === false) {
-                echo "break cause buf is false\n";
                 break;
             }
             $big5_string .= $buf;
-            echo "length: " . strlen($buf) . "\n";
             if ($len != 1024) {
-                echo "break cause buf is less than 1024\n";
                 break;
             }
          }

--- a/src/CKIPClient.php
+++ b/src/CKIPClient.php
@@ -85,7 +85,23 @@ class CKIPClient
          $socket = socket_create(AF_INET, SOCK_STREAM, $protocol);
          socket_connect($socket, $this->server_ip, $this->server_port);
          socket_write($socket, $message);
-         $this->return_text = iconv("big5", "utf-8", socket_read($socket, strlen($message)*3));
+
+         $big5_string = '';
+         $buf = '';
+         while( $buf = socket_read($socket, 1024)) {
+            $len = strlen($buf);
+            if ($buf === false) {
+                echo "break cause buf is false\n";
+                break;
+            }
+            $big5_string .= $buf;
+            echo "length: " . strlen($buf) . "\n";
+            if ($len != 1024) {
+                echo "break cause buf is less than 1024\n";
+                break;
+            }
+         }
+         $this->return_text = iconv("big5", "utf-8", $big5_string);
 
          socket_shutdown($socket);
          socket_close($socket);


### PR DESCRIPTION
Hi, 這是三年前的修正，當時忘了 PR。
這個 PR 可解決 CKIP response 較長時被截斷的 parse 錯誤以及超過 socket buffer size 造成錯誤等問題。

謝謝您提供這個 client，節省了我們許多開發時間。
p.s. 後續我很少再使用 CKIP，轉而投靠 jieba 了，主要原因除了速度外，斷詞還是要能自己隨時修改、訓練比較實用。 :p 
